### PR TITLE
Speed Up CI/CD Pipelines

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,13 +27,12 @@ jobs:
     
     # Must be placed after docker build and unit tests since
     # this action seems to reset docker and remove the buildx plugin
-    - name: Authenticate to GitHub Packages Docker Image Registry
+    - name: Authenticate to Docker Hub
       id: docker-login
       uses: azure/docker-login@v1
       with:
-        login-server: docker.pkg.github.com
-        username: $GITHUB_ACTOR
-        password: ${{ secrets.GITHUB_TOKEN }}
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
     - name: Push Docker Images
       id: docker-push

--- a/common.sh
+++ b/common.sh
@@ -5,10 +5,10 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-GH_PKG_ROOT=docker.pkg.github.com/ece-492-w2020-group-6/smart-blinds-rpi
-PRE_BUILD_STAGE_IMAGE=$GH_PKG_ROOT/rpi:pre-build-stage
-BUILD_STAGE_IMAGE=$GH_PKG_ROOT/rpi:build-stage
-RPI_IMAGE=$GH_PKG_ROOT/rpi:latest
+DH_PKG_REPO=ece492w2020group6/smart-blinds-rpi
+PRE_BUILD_STAGE_IMAGE=$DH_PKG_REPO:pre-build-stage
+BUILD_STAGE_IMAGE=$DH_PKG_REPO:build-stage
+RPI_IMAGE=$DH_PKG_REPO:latest
 
 # Enable host x86 machine to run ARM executables with QEMU
 docker run --rm --privileged docker/binfmt:820fdd95a9972a5308930a2bdfb8573dd4447ad3

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -24,17 +24,20 @@ docker pull $RPI_IMAGE || true
 
 # Build the pre build stage image:
 docker buildx build --platform linux/arm/v7 --load --target pre-build-image \
+    --build-arg BUILDKIT_INLINE_CACHE=1 \
     --cache-from=$PRE_BUILD_STAGE_IMAGE \
     --tag $PRE_BUILD_STAGE_IMAGE .
 
 # Build the build stage image:
 docker buildx build --platform linux/arm/v7 --load --target build-image \
+    --build-arg BUILDKIT_INLINE_CACHE=1 \
     --cache-from=$PRE_BUILD_STAGE_IMAGE \
     --cache-from=$BUILD_STAGE_IMAGE \
     --tag $BUILD_STAGE_IMAGE .
 
 # Build the runtime stage image:
 docker buildx build --platform linux/arm/v7 --load --target runtime-image \
+    --build-arg BUILDKIT_INLINE_CACHE=1 \
     --cache-from=$PRE_BUILD_STAGE_IMAGE \
     --cache-from=$BUILD_STAGE_IMAGE \
     --cache-from=$RPI_IMAGE \


### PR DESCRIPTION
This PR improves the speed and fixes CI/CD failures by:
- in-lining docker image cache metadata into the docker image
    - this is needed since buildkit (used by docker buildx) doesn't create cacheable images by default
    - this was why the builds had to be done from scratch and why it took so long
    - fixed by applying command seen in https://github.com/moby/moby/issues/39003
- publishing docker images to [DockerHub](https://hub.docker.com/r/ece492w2020group6/smart-blinds-rpi)
    - GitHub Packages is broken since it needs to [authenticate to pull public images](https://github.community/t5/GitHub-Actions/docker-pull-from-public-GitHub-Package-Registry-fail-with-quot/td-p/32782)
    - Using GitHub packages also threw warnings when using docker buildx that don't exist when using DockerHub
    - These docker images can then be pulled to populate the Docker cache in order to reduce build times