### PR TITLE
small timing adjustment for tiime block boundaries

### DIFF
--- a/blinds/blinds_schedule.py
+++ b/blinds/blinds_schedule.py
@@ -107,7 +107,7 @@ class ScheduleTimeBlock:
         if time < self._start:
             return -1
         
-        if time < self._end:
+        if time <= self._end:
             return 0
 
         return 1


### PR DESCRIPTION
Adjust time block boundary checking to include end time within the block. There would otherwise be an issue setting blocks that end at midnight. 